### PR TITLE
feat: Add SMTP RCPT TO verification for mailbox existence

### DIFF
--- a/internal/config/smtp_config.go
+++ b/internal/config/smtp_config.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"os"
+	"time"
+
+	"emailvalidator/pkg/validator"
+)
+
+// LoadSMTPVerifierConfig loads SMTP verifier configuration from environment variables
+func LoadSMTPVerifierConfig() validator.SMTPVerifierConfig {
+	config := validator.DefaultSMTPVerifierConfig()
+
+	// SMTP_VERIFY_ENABLED - defaults to true (enabled by default)
+	if os.Getenv("SMTP_VERIFY_ENABLED") == "false" {
+		config.Enabled = false
+	}
+
+	// SMTP_VERIFY_TIMEOUT - defaults to 10s
+	if timeout := os.Getenv("SMTP_VERIFY_TIMEOUT"); timeout != "" {
+		if d, err := time.ParseDuration(timeout); err == nil {
+			config.Timeout = d
+		}
+	}
+
+	// SMTP_VERIFY_HELO_HOST - defaults to "localhost"
+	if host := os.Getenv("SMTP_VERIFY_HELO_HOST"); host != "" {
+		config.HeloHostname = host
+	}
+
+	// SMTP_VERIFY_MAIL_FROM - defaults to "verify@localhost"
+	if mailFrom := os.Getenv("SMTP_VERIFY_MAIL_FROM"); mailFrom != "" {
+		config.MailFrom = mailFrom
+	}
+
+	return config
+}

--- a/internal/model/email.go
+++ b/internal/model/email.go
@@ -15,16 +15,19 @@ const (
 	ValidationStatusInvalidDomain ValidationStatus = "INVALID_DOMAIN"
 	ValidationStatusNoMXRecords   ValidationStatus = "NO_MX_RECORDS"
 	ValidationStatusDisposable    ValidationStatus = "DISPOSABLE"
+	ValidationStatusCatchAll      ValidationStatus = "CATCH_ALL" // Domain accepts all addresses
 )
 
 // ValidationResults represents the results of various validation checks
 type ValidationResults struct {
-	Syntax        bool `json:"syntax"`
-	DomainExists  bool `json:"domain_exists"`
-	MXRecords     bool `json:"mx_records"`
-	MailboxExists bool `json:"mailbox_exists"`
-	IsDisposable  bool `json:"is_disposable"`
-	IsRoleBased   bool `json:"is_role_based"`
+	Syntax        bool  `json:"syntax"`
+	DomainExists  bool  `json:"domain_exists"`
+	MXRecords     bool  `json:"mx_records"`
+	MailboxExists bool  `json:"mailbox_exists"`
+	IsDisposable  bool  `json:"is_disposable"`
+	IsRoleBased   bool  `json:"is_role_based"`
+	SMTPVerified  *bool `json:"smtp_verified,omitempty"` // nil if not checked, true if mailbox confirmed via SMTP
+	IsCatchAll    *bool `json:"is_catch_all,omitempty"`  // nil if not checked, true if domain accepts all addresses
 }
 
 // EmailValidationRequest represents a request to validate a single email

--- a/internal/service/email_service.go
+++ b/internal/service/email_service.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"emailvalidator/internal/config"
 	"emailvalidator/internal/model"
 	"emailvalidator/pkg/validator"
 )
@@ -18,6 +19,7 @@ type EmailService struct {
 	emailRuleValidator  EmailRuleValidator
 	domainValidator     DomainValidator
 	domainValidationSvc DomainValidationService
+	smtpVerificationSvc SMTPVerificationService
 	batchValidationSvc  *BatchValidationService
 	metricsCollector    MetricsCollector
 	startTime           time.Time
@@ -33,12 +35,18 @@ func NewEmailService() (*EmailService, error) {
 
 	metricsAdapter := NewMetricsAdapter()
 	domainValidationSvc := NewConcurrentDomainValidationService(emailValidator)
+
+	// Load SMTP config and create verification service
+	smtpConfig := config.LoadSMTPVerifierConfig()
+	smtpVerificationSvc := NewSMTPVerificationService(smtpConfig)
+
 	batchValidationSvc := NewBatchValidationService(emailValidator, domainValidationSvc, metricsAdapter)
 
 	return &EmailService{
 		emailRuleValidator:  emailValidator,
 		domainValidator:     emailValidator,
 		domainValidationSvc: domainValidationSvc,
+		smtpVerificationSvc: smtpVerificationSvc,
 		batchValidationSvc:  batchValidationSvc,
 		metricsCollector:    metricsAdapter,
 		startTime:           time.Now(),
@@ -111,7 +119,37 @@ func (s *EmailService) ValidateEmail(email string) model.EmailValidationResponse
 	response.Validations.MXRecords = hasMX
 	response.Validations.IsDisposable = isDisposable
 	response.Validations.IsRoleBased = s.emailRuleValidator.IsRoleBased(email)
-	response.Validations.MailboxExists = hasMX
+	response.Validations.MailboxExists = hasMX // Default to MX result, will be updated by SMTP
+
+	// Perform SMTP verification if MX records exist and service is enabled
+	if hasMX && s.smtpVerificationSvc != nil && s.smtpVerificationSvc.IsEnabled() {
+		mxRecords, err := s.domainValidator.GetMXRecords(domain)
+		if err == nil && len(mxRecords) > 0 {
+			smtpResult := s.smtpVerificationSvc.VerifyMailbox(context.Background(), email, domain, mxRecords)
+
+			if !smtpResult.Skipped {
+				// Set SMTP verification results
+				smtpVerified := smtpResult.Verified
+				response.Validations.SMTPVerified = &smtpVerified
+
+				isCatchAll := smtpResult.IsCatchAll
+				response.Validations.IsCatchAll = &isCatchAll
+
+				// Update MailboxExists based on SMTP result
+				if smtpResult.IsCatchAll {
+					// Catch-all domains always accept, so we can't truly verify
+					response.Validations.MailboxExists = true
+				} else if smtpResult.Verified {
+					// SMTP confirmed mailbox exists
+					response.Validations.MailboxExists = true
+				} else if smtpResult.ResponseCode == 550 || smtpResult.ResponseCode == 553 || smtpResult.ResponseCode == 551 {
+					// SMTP confirmed mailbox does NOT exist
+					response.Validations.MailboxExists = false
+				}
+				// If error or timeout, keep MailboxExists = hasMX (graceful fallback)
+			}
+		}
+	}
 
 	// Always check for typo suggestions
 	suggestions := s.emailRuleValidator.GetTypoSuggestions(email)
@@ -133,7 +171,18 @@ func (s *EmailService) ValidateEmail(email string) model.EmailValidationResponse
 		"is_disposable":  response.Validations.IsDisposable,
 		"is_role_based":  response.Validations.IsRoleBased,
 	}
+
+	// Add SMTP verification to score if available
+	if response.Validations.SMTPVerified != nil {
+		validationMap["smtp_verified"] = *response.Validations.SMTPVerified
+	}
+
 	response.Score = s.emailRuleValidator.CalculateScore(validationMap)
+
+	// Apply catch-all penalty (verification is uncertain for catch-all domains)
+	if response.Validations.IsCatchAll != nil && *response.Validations.IsCatchAll {
+		response.Score = max(0, response.Score-10)
+	}
 
 	// Reduce score if there's a typo suggestion
 	if response.TypoSuggestion != "" {
@@ -152,6 +201,12 @@ func (s *EmailService) ValidateEmail(email string) model.EmailValidationResponse
 		response.Score = 40 // Override score for no MX records case
 	case response.Validations.IsDisposable:
 		response.Status = model.ValidationStatusDisposable
+	case response.Validations.IsCatchAll != nil && *response.Validations.IsCatchAll:
+		response.Status = model.ValidationStatusCatchAll
+	case !response.Validations.MailboxExists:
+		// Mailbox doesn't exist (confirmed by SMTP)
+		response.Status = model.ValidationStatusInvalid
+		response.Score = max(0, response.Score-30) // Heavy penalty for non-existent mailbox
 	case response.Score >= 90:
 		response.Status = model.ValidationStatusValid
 	case response.Score >= 70:
@@ -222,4 +277,9 @@ func (s *EmailService) SetEmailRuleValidator(validator EmailRuleValidator) {
 // SetDomainValidator sets the domain validator (for testing)
 func (s *EmailService) SetDomainValidator(validator DomainValidator) {
 	s.domainValidator = validator
+}
+
+// SetSMTPVerificationService sets the SMTP verification service (for testing)
+func (s *EmailService) SetSMTPVerificationService(svc SMTPVerificationService) {
+	s.smtpVerificationSvc = svc
 }

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -2,7 +2,10 @@ package service
 
 import (
 	"context"
+	"net"
+
 	"emailvalidator/internal/model"
+	"emailvalidator/pkg/validator"
 )
 
 // EmailValidator defines the contract for email validation operations
@@ -17,6 +20,7 @@ type DomainValidator interface {
 	ValidateDomain(domain string) bool
 	ValidateMXRecords(domain string) bool
 	IsDisposable(domain string) bool
+	GetMXRecords(domain string) ([]*net.MX, error)
 }
 
 // EmailRuleValidator defines the contract for email-specific rule validations
@@ -44,4 +48,14 @@ type AliasDetector interface {
 	// DetectAlias checks if the email is an alias and returns the canonical email if it is
 	// Returns empty string if the email is not an alias
 	DetectAlias(email string) string
+}
+
+// SMTPVerificationService defines the contract for SMTP mailbox verification
+type SMTPVerificationService interface {
+	// VerifyMailbox performs SMTP RCPT TO verification to check if mailbox exists
+	VerifyMailbox(ctx context.Context, email, domain string, mxRecords []*net.MX) validator.SMTPVerificationResult
+	// IsCatchAll checks if domain is a catch-all (accepts all addresses)
+	IsCatchAll(ctx context.Context, domain string, mxRecords []*net.MX) (bool, error)
+	// IsEnabled returns whether SMTP verification is enabled
+	IsEnabled() bool
 }

--- a/internal/service/smtp_verification_service.go
+++ b/internal/service/smtp_verification_service.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"emailvalidator/pkg/validator"
+)
+
+// DefaultSMTPVerificationService implements SMTPVerificationService
+type DefaultSMTPVerificationService struct {
+	verifier     validator.SMTPVerifier
+	cacheManager *validator.SMTPCacheManager
+	config       validator.SMTPVerifierConfig
+}
+
+// NewSMTPVerificationService creates a new SMTP verification service
+func NewSMTPVerificationService(config validator.SMTPVerifierConfig) *DefaultSMTPVerificationService {
+	return &DefaultSMTPVerificationService{
+		verifier:     validator.NewDefaultSMTPVerifier(config),
+		cacheManager: validator.NewSMTPCacheManager(24 * time.Hour),
+		config:       config,
+	}
+}
+
+// NewSMTPVerificationServiceWithVerifier creates a service with a custom verifier (for testing)
+func NewSMTPVerificationServiceWithVerifier(config validator.SMTPVerifierConfig, verifier validator.SMTPVerifier) *DefaultSMTPVerificationService {
+	return &DefaultSMTPVerificationService{
+		verifier:     verifier,
+		cacheManager: validator.NewSMTPCacheManager(24 * time.Hour),
+		config:       config,
+	}
+}
+
+// IsEnabled returns whether SMTP verification is enabled
+func (s *DefaultSMTPVerificationService) IsEnabled() bool {
+	return s.config.Enabled
+}
+
+// VerifyMailbox performs SMTP RCPT TO verification with catch-all detection
+func (s *DefaultSMTPVerificationService) VerifyMailbox(ctx context.Context, email, domain string, mxRecords []*net.MX) validator.SMTPVerificationResult {
+	if !s.config.Enabled {
+		return validator.SMTPVerificationResult{Skipped: true, SkipReason: "disabled"}
+	}
+
+	if len(mxRecords) == 0 {
+		return validator.SMTPVerificationResult{Skipped: true, SkipReason: "no_mx_records"}
+	}
+
+	// Check if domain is known to be catch-all (cached)
+	if isCatchAll, found := s.cacheManager.GetCatchAll(domain); found {
+		if isCatchAll {
+			return validator.SMTPVerificationResult{
+				Verified:   true, // Can't verify individual mailboxes on catch-all
+				IsCatchAll: true,
+			}
+		}
+		// Domain is not catch-all, proceed with verification
+	} else {
+		// Not in cache - detect catch-all first
+		isCatchAll, err := s.verifier.DetectCatchAll(ctx, domain, mxRecords)
+		if err == nil {
+			s.cacheManager.SetCatchAll(domain, isCatchAll)
+		}
+
+		if isCatchAll {
+			return validator.SMTPVerificationResult{
+				Verified:   true,
+				IsCatchAll: true,
+			}
+		}
+	}
+
+	// Domain is not catch-all, verify the specific mailbox
+	result := s.verifier.VerifyMailbox(ctx, email, domain, mxRecords)
+
+	return result
+}
+
+// IsCatchAll checks if domain is a catch-all (accepts all addresses)
+func (s *DefaultSMTPVerificationService) IsCatchAll(ctx context.Context, domain string, mxRecords []*net.MX) (bool, error) {
+	// Check cache first
+	if isCatchAll, found := s.cacheManager.GetCatchAll(domain); found {
+		return isCatchAll, nil
+	}
+
+	// Detect catch-all
+	isCatchAll, err := s.verifier.DetectCatchAll(ctx, domain, mxRecords)
+	if err == nil {
+		s.cacheManager.SetCatchAll(domain, isCatchAll)
+	}
+
+	return isCatchAll, err
+}
+
+// ClearCache clears the catch-all cache (useful for testing)
+func (s *DefaultSMTPVerificationService) ClearCache() {
+	s.cacheManager.Clear()
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -227,13 +227,21 @@ components:
               description: Whether the domain has valid MX records
             mailbox_exists:
               type: boolean
-              description: Whether the mailbox exists
+              description: Whether the mailbox exists (confirmed by SMTP if available)
             is_disposable:
               type: boolean
               description: Whether the email is from a disposable provider
             is_role_based:
               type: boolean
               description: Whether the email is a role-based address
+            smtp_verified:
+              type: boolean
+              nullable: true
+              description: Whether the mailbox was verified via SMTP RCPT TO handshake. Null if SMTP verification was not performed.
+            is_catch_all:
+              type: boolean
+              nullable: true
+              description: Whether the domain is a catch-all (accepts all addresses). Null if not checked.
         score:
           type: integer
           minimum: 0
@@ -250,6 +258,7 @@ components:
             - INVALID_DOMAIN
             - NO_MX_RECORDS
             - DISPOSABLE
+            - CATCH_ALL
           description: Validation status
         aliasOf:
           type: string

--- a/pkg/validator/domain_validator.go
+++ b/pkg/validator/domain_validator.go
@@ -1,6 +1,7 @@
 package validator
 
 import (
+	"net"
 	"time"
 
 	"emailvalidator/pkg/monitoring"
@@ -68,4 +69,10 @@ func (v *DomainValidator) ValidateMX(domain string) bool {
 
 	// Otherwise, the domain has valid MX records
 	return true
+}
+
+// GetMXRecords returns the MX records for a domain
+// Used by SMTP verification to connect to mail servers
+func (v *DomainValidator) GetMXRecords(domain string) ([]*net.MX, error) {
+	return v.resolver.LookupMX(domain)
 }

--- a/pkg/validator/email.go
+++ b/pkg/validator/email.go
@@ -1,6 +1,7 @@
 package validator
 
 import (
+	"net"
 	"strings"
 	"time"
 )
@@ -93,6 +94,11 @@ func (v *EmailValidator) ValidateMXRecords(domain string) bool {
 	return v.domainValidator.ValidateMX(domain)
 }
 
+// GetMXRecords returns the MX records for a domain
+func (v *EmailValidator) GetMXRecords(domain string) ([]*net.MX, error) {
+	return v.domainValidator.GetMXRecords(domain)
+}
+
 // IsDisposable checks if the email domain is from a disposable email provider
 func (v *EmailValidator) IsDisposable(domain string) bool {
 	return v.disposableValidator.Validate(domain)
@@ -107,10 +113,11 @@ func (v *EmailValidator) IsRoleBased(email string) bool {
 func (v *EmailValidator) CalculateScore(validations map[string]bool) int {
 	score := 0
 	weights := map[string]int{
-		"syntax":         20,
-		"domain_exists":  20,
-		"mx_records":     20,
-		"mailbox_exists": 20,
+		"syntax":         15,
+		"domain_exists":  15,
+		"mx_records":     15,
+		"mailbox_exists": 15,
+		"smtp_verified":  20, // SMTP verification bonus (higher weight for confirmed mailbox)
 		"is_disposable":  10,
 		"is_role_based":  10,
 	}

--- a/pkg/validator/smtp_cache.go
+++ b/pkg/validator/smtp_cache.go
@@ -1,0 +1,80 @@
+package validator
+
+import (
+	"sync"
+	"time"
+)
+
+// SMTPCacheEntry represents a cached SMTP verification result
+type SMTPCacheEntry struct {
+	IsCatchAll bool
+	Timestamp  time.Time
+}
+
+// SMTPCacheManager handles caching of SMTP-related results
+// Only caches domain-level data (catch-all status), never individual emails
+// This maintains GDPR/CCPA compliance by not storing email addresses
+type SMTPCacheManager struct {
+	catchAllCache map[string]SMTPCacheEntry
+	cacheMutex    sync.RWMutex
+	cacheDuration time.Duration
+}
+
+// NewSMTPCacheManager creates a new SMTP cache manager
+func NewSMTPCacheManager(duration time.Duration) *SMTPCacheManager {
+	return &SMTPCacheManager{
+		catchAllCache: make(map[string]SMTPCacheEntry, 100),
+		cacheDuration: duration,
+	}
+}
+
+// GetCatchAll retrieves cached catch-all status for a domain
+// Returns (isCatchAll, found)
+func (m *SMTPCacheManager) GetCatchAll(domain string) (bool, bool) {
+	m.cacheMutex.RLock()
+	defer m.cacheMutex.RUnlock()
+
+	entry, ok := m.catchAllCache[domain]
+	if !ok {
+		return false, false
+	}
+
+	// Check if entry has expired
+	if time.Since(entry.Timestamp) > m.cacheDuration {
+		return false, false
+	}
+
+	return entry.IsCatchAll, true
+}
+
+// SetCatchAll stores catch-all status for a domain
+func (m *SMTPCacheManager) SetCatchAll(domain string, isCatchAll bool) {
+	m.cacheMutex.Lock()
+	defer m.cacheMutex.Unlock()
+
+	m.catchAllCache[domain] = SMTPCacheEntry{
+		IsCatchAll: isCatchAll,
+		Timestamp:  time.Now(),
+	}
+}
+
+// ClearExpired removes expired entries from the cache
+func (m *SMTPCacheManager) ClearExpired() {
+	m.cacheMutex.Lock()
+	defer m.cacheMutex.Unlock()
+
+	now := time.Now()
+	for domain, entry := range m.catchAllCache {
+		if now.Sub(entry.Timestamp) > m.cacheDuration {
+			delete(m.catchAllCache, domain)
+		}
+	}
+}
+
+// Clear removes all entries from the cache
+func (m *SMTPCacheManager) Clear() {
+	m.cacheMutex.Lock()
+	defer m.cacheMutex.Unlock()
+
+	m.catchAllCache = make(map[string]SMTPCacheEntry, 100)
+}

--- a/pkg/validator/smtp_codes.go
+++ b/pkg/validator/smtp_codes.go
@@ -1,0 +1,60 @@
+package validator
+
+// SMTP response code constants
+const (
+	SMTPCodeOK                = 250 // Requested action completed
+	SMTPCodeUserNotLocal      = 251 // User not local, will forward
+	SMTPCodeStartMail         = 354 // Start mail input
+	SMTPCodeServiceNotAvail   = 421 // Service not available (greylisting)
+	SMTPCodeMailboxBusy       = 450 // Mailbox busy (greylisting)
+	SMTPCodeLocalError        = 451 // Local error (greylisting)
+	SMTPCodeInsufficientSpace = 452 // Insufficient storage
+	SMTPCodeCommandError      = 500 // Syntax error
+	SMTPCodeParamError        = 501 // Syntax error in parameters
+	SMTPCodeNotImplemented    = 502 // Command not implemented
+	SMTPCodeBadSequence       = 503 // Bad sequence of commands
+	SMTPCodeParamNotImpl      = 504 // Parameter not implemented
+	SMTPCodeMailboxNotFound   = 550 // Mailbox not found
+	SMTPCodeUserNotLocal550   = 551 // User not local
+	SMTPCodeExceededStorage   = 552 // Exceeded storage allocation
+	SMTPCodeMailboxNameErr    = 553 // Mailbox name not allowed
+	SMTPCodeTransactionFail   = 554 // Transaction failed
+)
+
+// SMTPResponseCategory categorizes SMTP responses
+type SMTPResponseCategory int
+
+const (
+	SMTPCategorySuccess   SMTPResponseCategory = iota // 2xx responses
+	SMTPCategoryTemporary                             // 4xx responses (greylisting, rate limiting)
+	SMTPCategoryPermanent                             // 5xx responses (mailbox doesn't exist)
+	SMTPCategoryUnknown                               // Other responses
+)
+
+// CategorizeResponse determines the category of an SMTP response code
+func CategorizeResponse(code int) SMTPResponseCategory {
+	switch {
+	case code >= 200 && code < 300:
+		return SMTPCategorySuccess
+	case code >= 400 && code < 500:
+		return SMTPCategoryTemporary
+	case code >= 500 && code < 600:
+		return SMTPCategoryPermanent
+	default:
+		return SMTPCategoryUnknown
+	}
+}
+
+// IsGreylisting checks if response indicates greylisting or temporary rejection
+func IsGreylisting(code int) bool {
+	return code == SMTPCodeServiceNotAvail ||
+		code == SMTPCodeMailboxBusy ||
+		code == SMTPCodeLocalError
+}
+
+// IsMailboxNotFound checks if response indicates mailbox doesn't exist
+func IsMailboxNotFound(code int) bool {
+	return code == SMTPCodeMailboxNotFound ||
+		code == SMTPCodeMailboxNameErr ||
+		code == SMTPCodeUserNotLocal550
+}

--- a/pkg/validator/smtp_verifier.go
+++ b/pkg/validator/smtp_verifier.go
@@ -1,0 +1,45 @@
+package validator
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+// SMTPVerificationResult contains the results of SMTP verification
+type SMTPVerificationResult struct {
+	Verified     bool   // Whether SMTP verification confirmed mailbox exists
+	IsCatchAll   bool   // Whether domain is a catch-all (accepts all addresses)
+	ResponseCode int    // SMTP response code (250, 550, etc.)
+	ResponseMsg  string // SMTP response message
+	Error        error  // Any error that occurred during verification
+	Skipped      bool   // True if verification was skipped (e.g., no MX records)
+	SkipReason   string // Reason for skipping verification
+}
+
+// SMTPVerifier interface for SMTP mailbox verification
+type SMTPVerifier interface {
+	// VerifyMailbox performs SMTP RCPT TO verification to check if mailbox exists
+	VerifyMailbox(ctx context.Context, email, domain string, mxRecords []*net.MX) SMTPVerificationResult
+
+	// DetectCatchAll tests if domain accepts all email addresses (catch-all configuration)
+	DetectCatchAll(ctx context.Context, domain string, mxRecords []*net.MX) (bool, error)
+}
+
+// SMTPVerifierConfig holds configuration for SMTP verification
+type SMTPVerifierConfig struct {
+	Enabled      bool          // Enable/disable SMTP verification
+	Timeout      time.Duration // Connection timeout per MX server
+	HeloHostname string        // Hostname for HELO/EHLO command
+	MailFrom     string        // MAIL FROM address
+}
+
+// DefaultSMTPVerifierConfig returns sensible defaults for SMTP verification
+func DefaultSMTPVerifierConfig() SMTPVerifierConfig {
+	return SMTPVerifierConfig{
+		Enabled:      true, // Enabled by default per user preference
+		Timeout:      10 * time.Second,
+		HeloHostname: "localhost",
+		MailFrom:     "verify@localhost",
+	}
+}

--- a/pkg/validator/smtp_verifier_impl.go
+++ b/pkg/validator/smtp_verifier_impl.go
@@ -1,0 +1,219 @@
+package validator
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"net/smtp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// SMTPDialer interface for creating SMTP connections (mockable for testing)
+type SMTPDialer interface {
+	DialContext(ctx context.Context, network, addr string) (net.Conn, error)
+}
+
+// DefaultSMTPDialer uses net.Dialer for connections
+type DefaultSMTPDialer struct {
+	Timeout time.Duration
+}
+
+// DialContext creates a new TCP connection with context and timeout
+func (d *DefaultSMTPDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	dialer := &net.Dialer{Timeout: d.Timeout}
+	return dialer.DialContext(ctx, network, addr)
+}
+
+// DefaultSMTPVerifier implements SMTPVerifier interface
+type DefaultSMTPVerifier struct {
+	config SMTPVerifierConfig
+	dialer SMTPDialer
+}
+
+// NewDefaultSMTPVerifier creates a new SMTP verifier with default dialer
+func NewDefaultSMTPVerifier(config SMTPVerifierConfig) *DefaultSMTPVerifier {
+	return &DefaultSMTPVerifier{
+		config: config,
+		dialer: &DefaultSMTPDialer{Timeout: config.Timeout},
+	}
+}
+
+// NewSMTPVerifierWithDialer creates a verifier with custom dialer (for testing)
+func NewSMTPVerifierWithDialer(config SMTPVerifierConfig, dialer SMTPDialer) *DefaultSMTPVerifier {
+	return &DefaultSMTPVerifier{
+		config: config,
+		dialer: dialer,
+	}
+}
+
+// VerifyMailbox performs SMTP RCPT TO verification
+func (v *DefaultSMTPVerifier) VerifyMailbox(ctx context.Context, email, domain string, mxRecords []*net.MX) SMTPVerificationResult {
+	result := SMTPVerificationResult{}
+
+	// Skip if no MX records
+	if len(mxRecords) == 0 {
+		result.Skipped = true
+		result.SkipReason = "no_mx_records"
+		return result
+	}
+
+	// Sort MX by priority (lowest preference value first)
+	sortedMX := sortMXByPriority(mxRecords)
+
+	// Try each MX server in priority order
+	var lastErr error
+	for _, mx := range sortedMX {
+		// Check context cancellation
+		select {
+		case <-ctx.Done():
+			result.Error = ctx.Err()
+			return result
+		default:
+		}
+
+		host := strings.TrimSuffix(mx.Host, ".")
+		addr := net.JoinHostPort(host, "25")
+
+		code, msg, err := v.tryVerify(ctx, email, host, addr)
+		if err != nil {
+			lastErr = err
+			continue // Try next MX server
+		}
+
+		result.ResponseCode = code
+		result.ResponseMsg = msg
+
+		// Handle response based on category
+		switch CategorizeResponse(code) {
+		case SMTPCategorySuccess:
+			result.Verified = true
+			return result
+		case SMTPCategoryTemporary:
+			// Greylisting or temporary error - try next MX
+			lastErr = fmt.Errorf("temporary rejection: %d %s", code, msg)
+			continue
+		case SMTPCategoryPermanent:
+			if IsMailboxNotFound(code) {
+				result.Verified = false
+				return result
+			}
+			// Some other permanent error, try next MX
+			lastErr = fmt.Errorf("permanent error: %d %s", code, msg)
+			continue
+		}
+	}
+
+	// All MX servers failed
+	result.Error = lastErr
+	return result
+}
+
+// DetectCatchAll tests if domain accepts all addresses (catch-all configuration)
+func (v *DefaultSMTPVerifier) DetectCatchAll(ctx context.Context, domain string, mxRecords []*net.MX) (bool, error) {
+	// Generate a random address that definitely doesn't exist
+	randomLocal := generateRandomLocalPart()
+	randomEmail := randomLocal + "@" + domain
+
+	result := v.VerifyMailbox(ctx, randomEmail, domain, mxRecords)
+
+	if result.Error != nil {
+		return false, result.Error
+	}
+
+	if result.Skipped {
+		return false, nil
+	}
+
+	// If server accepts random address, it's a catch-all domain
+	return result.Verified, nil
+}
+
+// tryVerify attempts SMTP verification against a single mail server
+func (v *DefaultSMTPVerifier) tryVerify(ctx context.Context, email, host, addr string) (int, string, error) {
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(ctx, v.config.Timeout)
+	defer cancel()
+
+	// Connect to mail server
+	conn, err := v.dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return 0, "", fmt.Errorf("connection failed: %w", err)
+	}
+	defer conn.Close()
+
+	// Set deadline from context
+	if deadline, ok := ctx.Deadline(); ok {
+		conn.SetDeadline(deadline)
+	}
+
+	// Create SMTP client
+	client, err := smtp.NewClient(conn, host)
+	if err != nil {
+		return 0, "", fmt.Errorf("smtp client failed: %w", err)
+	}
+	defer client.Close()
+
+	// Send EHLO (or fall back to HELO automatically)
+	if err = client.Hello(v.config.HeloHostname); err != nil {
+		return 0, "", fmt.Errorf("hello failed: %w", err)
+	}
+
+	// Send MAIL FROM
+	if err = client.Mail(v.config.MailFrom); err != nil {
+		return 0, "", fmt.Errorf("mail from failed: %w", err)
+	}
+
+	// Send RCPT TO - this is where we verify the mailbox
+	err = client.Rcpt(email)
+
+	// Parse SMTP response from error (or success)
+	code, msg := parseSmtpError(err)
+
+	// Clean up - send RSET and QUIT
+	client.Reset()
+	client.Quit()
+
+	return code, msg, nil
+}
+
+// sortMXByPriority sorts MX records by preference (lowest first)
+func sortMXByPriority(mxRecords []*net.MX) []*net.MX {
+	sorted := make([]*net.MX, len(mxRecords))
+	copy(sorted, mxRecords)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Pref < sorted[j].Pref
+	})
+	return sorted
+}
+
+// generateRandomLocalPart creates a random non-existent address for catch-all detection
+func generateRandomLocalPart() string {
+	bytes := make([]byte, 16)
+	rand.Read(bytes)
+	return "verify-catchall-" + hex.EncodeToString(bytes)
+}
+
+// parseSmtpError extracts SMTP code and message from error
+func parseSmtpError(err error) (int, string) {
+	if err == nil {
+		return SMTPCodeOK, "OK"
+	}
+
+	msg := err.Error()
+
+	// Try to parse SMTP error format: "550 5.1.1 User unknown"
+	// First, try to extract the 3-digit code at the start
+	if len(msg) >= 3 {
+		if code, parseErr := strconv.Atoi(msg[:3]); parseErr == nil && code >= 200 && code < 600 {
+			return code, msg
+		}
+	}
+
+	// If we can't parse a code, return 0 to indicate unknown
+	return 0, msg
+}

--- a/tests/unit/service/email_service_unit_test.go
+++ b/tests/unit/service/email_service_unit_test.go
@@ -30,6 +30,8 @@ func (m *mockDNSResolver) LookupHost(domain string) ([]string, error) {
 }
 
 func TestServiceValidateEmail(t *testing.T) {
+	// Note: Without SMTP verification (mock resolver can't do SMTP), max score is 80
+	// SMTP verification adds 20 points to reach 100
 	tests := []struct {
 		name          string
 		email         string
@@ -39,11 +41,11 @@ func TestServiceValidateEmail(t *testing.T) {
 		wantStatus    model.ValidationStatus
 	}{
 		{
-			name:       "Valid email",
+			name:       "Valid email (without SMTP)",
 			email:      "user@example.com",
-			wantScore:  100,
+			wantScore:  80, // Without SMTP: 15+15+15+15+10+10 = 80
 			wantSyntax: true,
-			wantStatus: model.ValidationStatusValid,
+			wantStatus: model.ValidationStatusProbablyValid, // 80 >= 70, < 90
 		},
 		{
 			name:       "Invalid email format",
@@ -53,12 +55,12 @@ func TestServiceValidateEmail(t *testing.T) {
 			wantStatus: model.ValidationStatusInvalidFormat,
 		},
 		{
-			name:          "Role-based email",
+			name:          "Role-based email (without SMTP)",
 			email:         "admin@example.com",
-			wantScore:     90,
+			wantScore:     70, // 15+15+15+15+10 = 70 (no is_role_based bonus)
 			wantSyntax:    true,
 			wantRoleBased: true,
-			wantStatus:    model.ValidationStatusValid,
+			wantStatus:    model.ValidationStatusProbablyValid, // 70 >= 70
 		},
 		{
 			name:       "Empty email",
@@ -68,11 +70,11 @@ func TestServiceValidateEmail(t *testing.T) {
 			wantStatus: model.ValidationStatusMissingEmail,
 		},
 		{
-			name:       "Email with typo",
+			name:       "Email with typo (without SMTP)",
 			email:      "user@outlok.com",
-			wantScore:  80, // 100 - 20 (typo penalty)
+			wantScore:  60, // 80 - 20 (typo penalty)
 			wantSyntax: true,
-			wantStatus: model.ValidationStatusProbablyValid,
+			wantStatus: model.ValidationStatusInvalid, // 60 < 70
 		},
 	}
 

--- a/tests/unit/service/mocks/service_mocks.go
+++ b/tests/unit/service/mocks/service_mocks.go
@@ -3,6 +3,9 @@ package mocks
 
 import (
 	"context"
+	"net"
+
+	"emailvalidator/pkg/validator"
 
 	"github.com/stretchr/testify/mock"
 )
@@ -57,6 +60,14 @@ func (m *MockDomainValidator) IsDisposable(domain string) bool {
 	return args.Bool(0)
 }
 
+func (m *MockDomainValidator) GetMXRecords(domain string) ([]*net.MX, error) {
+	args := m.Called(domain)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*net.MX), args.Error(1)
+}
+
 // MockDomainValidationService mocks the DomainValidationService interface
 type MockDomainValidationService struct {
 	mock.Mock
@@ -78,4 +89,39 @@ func (m *MockMetricsCollector) RecordValidationScore(name string, score float64)
 
 func (m *MockMetricsCollector) UpdateMemoryUsage(heapInUse, stackInUse float64) {
 	m.Called(heapInUse, stackInUse)
+}
+
+// MockSMTPVerificationService mocks the SMTPVerificationService interface
+type MockSMTPVerificationService struct {
+	mock.Mock
+}
+
+func (m *MockSMTPVerificationService) VerifyMailbox(ctx context.Context, email, domain string, mxRecords []*net.MX) validator.SMTPVerificationResult {
+	args := m.Called(ctx, email, domain, mxRecords)
+	return args.Get(0).(validator.SMTPVerificationResult)
+}
+
+func (m *MockSMTPVerificationService) IsCatchAll(ctx context.Context, domain string, mxRecords []*net.MX) (bool, error) {
+	args := m.Called(ctx, domain, mxRecords)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockSMTPVerificationService) IsEnabled() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+// MockSMTPVerifier mocks the SMTPVerifier interface
+type MockSMTPVerifier struct {
+	mock.Mock
+}
+
+func (m *MockSMTPVerifier) VerifyMailbox(ctx context.Context, email, domain string, mxRecords []*net.MX) validator.SMTPVerificationResult {
+	args := m.Called(ctx, email, domain, mxRecords)
+	return args.Get(0).(validator.SMTPVerificationResult)
+}
+
+func (m *MockSMTPVerifier) DetectCatchAll(ctx context.Context, domain string, mxRecords []*net.MX) (bool, error) {
+	args := m.Called(ctx, domain, mxRecords)
+	return args.Bool(0), args.Error(1)
 }

--- a/tests/unit/validator/validator_unit_test.go
+++ b/tests/unit/validator/validator_unit_test.go
@@ -228,7 +228,7 @@ func TestCalculateScore(t *testing.T) {
 		want        int
 	}{
 		{
-			name: "All validations pass",
+			name: "All validations pass (without SMTP)",
 			validations: map[string]bool{
 				"syntax":         true,
 				"domain_exists":  true,
@@ -237,7 +237,20 @@ func TestCalculateScore(t *testing.T) {
 				"is_disposable":  false,
 				"is_role_based":  false,
 			},
-			want: 100,
+			want: 80, // 15+15+15+15+10+10 = 80 (SMTP adds 20 more)
+		},
+		{
+			name: "All validations pass (with SMTP)",
+			validations: map[string]bool{
+				"syntax":         true,
+				"domain_exists":  true,
+				"mx_records":     true,
+				"mailbox_exists": true,
+				"smtp_verified":  true,
+				"is_disposable":  false,
+				"is_role_based":  false,
+			},
+			want: 100, // 15+15+15+15+20+10+10 = 100
 		},
 		{
 			name: "Only syntax valid",
@@ -249,10 +262,10 @@ func TestCalculateScore(t *testing.T) {
 				"is_disposable":  true,
 				"is_role_based":  true,
 			},
-			want: 20,
+			want: 15, // Only syntax (15)
 		},
 		{
-			name: "Role-based email",
+			name: "Role-based email (without SMTP)",
 			validations: map[string]bool{
 				"syntax":         true,
 				"domain_exists":  true,
@@ -261,7 +274,7 @@ func TestCalculateScore(t *testing.T) {
 				"is_disposable":  false,
 				"is_role_based":  true,
 			},
-			want: 90,
+			want: 70, // 15+15+15+15+10 = 70 (no role_based bonus)
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Implements SMTP RCPT TO handshake verification to confirm whether a specific email address actually exists
- Detects catch-all domains that accept all addresses (preventing false positives)
- Adds graceful fallback to MX-only validation on connection errors
- Configurable via environment variables

## Problem

The current email verification flow only validates domain existence and MX records, but never performs the deeper SMTP handshake required to confirm whether a specific mailbox exists. This causes false positives:

```
john@company.com       → VALID (correct if exists)
doesnotexist@company.com → VALID (WRONG - should be invalid!)
```

## Solution

This PR adds SMTP RCPT TO verification:

1. **Connect to MX server** (highest priority first)
2. **EHLO/HELO handshake**
3. **MAIL FROM** with configurable sender
4. **RCPT TO** with target email - this is where the server responds:
   - `250 OK` → Mailbox exists
   - `550 User not found` → Mailbox does NOT exist

### Catch-All Detection

Before verifying an email, we first test with a random non-existent address:
- If accepted → Domain is catch-all (can't verify individual mailboxes)
- If rejected → Domain is NOT catch-all, proceed with real verification

## New Response Fields

```json
{
  "validations": {
    "smtp_verified": true,    // null if not checked, true if confirmed
    "is_catch_all": false     // null if not checked, true if catch-all domain
  },
  "status": "CATCH_ALL"       // New status for catch-all domains
}
```

## Configuration

| Variable | Default | Description |
|----------|---------|-------------|
| `SMTP_VERIFY_ENABLED` | `true` | Enable/disable SMTP verification |
| `SMTP_VERIFY_TIMEOUT` | `10s` | Connection timeout per MX server |
| `SMTP_VERIFY_HELO_HOST` | `localhost` | Hostname for HELO/EHLO |
| `SMTP_VERIFY_MAIL_FROM` | `verify@localhost` | MAIL FROM address |

## Files Changed

### New Files (6)
- `pkg/validator/smtp_codes.go` - SMTP response code constants
- `pkg/validator/smtp_verifier.go` - Interface and config types
- `pkg/validator/smtp_verifier_impl.go` - SMTP handshake implementation
- `pkg/validator/smtp_cache.go` - Catch-all cache (24h TTL)
- `internal/service/smtp_verification_service.go` - Service wrapper
- `internal/config/smtp_config.go` - Environment config loader

### Modified Files (9)
- `pkg/validator/domain_validator.go` - Added GetMXRecords()
- `pkg/validator/email.go` - Updated scoring with smtp_verified
- `internal/model/email.go` - Added SMTPVerified, IsCatchAll fields
- `internal/service/interfaces.go` - Added SMTPVerificationService interface
- `internal/service/email_service.go` - Integrated SMTP verification
- `openapi.yaml` - Documented new fields and CATCH_ALL status
- Test files updated for new scoring

## Test plan

- [x] Unit tests pass (`go test ./... -skip "Load"`)
- [x] Race detection passes (`go test -race ./...`)
- [x] Build succeeds (`go build ./...`)
- [ ] Manual testing with real email addresses
- [ ] Test catch-all detection on known catch-all domains

Fixes #14
Fixes #17