### PR TITLE
Add domain normalization and subdomain validation to disposable email checker

### DIFF
--- a/config/disposable_domains.txt
+++ b/config/disposable_domains.txt
@@ -4019,3 +4019,4 @@ zyns.com
 zzi.us
 zzrgg.com
 zzz.com
+tempmail.com

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/prometheus/client_golang v1.19.0
 	github.com/redis/go-redis/v9 v9.7.3
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/net v0.24.0
 )
 
 require (
@@ -19,7 +20,8 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
-	golang.org/x/sys v0.16.0 // indirect
+	golang.org/x/sys v0.19.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,12 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
-golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/net v0.24.0 h1:1PcaxkF854Fu3+lvBIx5SYn9wRlBzzcnHZSiaFFAb0w=
+golang.org/x/net v0.24.0/go.mod h1:2Q7sJY5mzlzWjKtYUEXSlBWCdyaioyXzRB2RtU8KVE8=
+golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
+golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/validator/disposable_validator.go
+++ b/pkg/validator/disposable_validator.go
@@ -3,11 +3,16 @@ package validator
 import (
 	"os"
 	"path/filepath"
+	"strings"
+
+	"golang.org/x/net/idna"
+	"golang.org/x/net/publicsuffix"
 )
 
 // DisposableValidator handles disposable email validation
 type DisposableValidator struct {
-	disposableDomains map[string]struct{}
+	disposableDomains  map[string]struct{}
+	registrableDomains map[string]struct{}
 }
 
 // NewDisposableValidator creates a new instance of DisposableValidator using the config file
@@ -37,11 +42,20 @@ func NewDisposableValidator() (*DisposableValidator, error) {
 // NewDisposableValidatorWithDomains creates a new instance of DisposableValidator with a custom list of domains
 func NewDisposableValidatorWithDomains(domains []string) *DisposableValidator {
 	disposableDomains := make(map[string]struct{}, len(domains))
+	registrableDomains := make(map[string]struct{}, len(domains))
 	for _, domain := range domains {
-		disposableDomains[domain] = struct{}{}
+		normalized := normalizeDomain(domain)
+		if normalized == "" {
+			continue
+		}
+		disposableDomains[normalized] = struct{}{}
+		if registrable, err := publicsuffix.EffectiveTLDPlusOne(normalized); err == nil && registrable == normalized {
+			registrableDomains[registrable] = struct{}{}
+		}
 	}
 	return &DisposableValidator{
-		disposableDomains: disposableDomains,
+		disposableDomains:  disposableDomains,
+		registrableDomains: registrableDomains,
 	}
 }
 
@@ -56,6 +70,30 @@ func NewDisposableValidatorWithReader(reader DomainReader) (*DisposableValidator
 
 // Validate checks if the email domain is from a disposable email provider
 func (v *DisposableValidator) Validate(domain string) bool {
-	_, exists := v.disposableDomains[domain]
+	normalized := normalizeDomain(domain)
+	if normalized == "" {
+		return false
+	}
+	if _, exists := v.disposableDomains[normalized]; exists {
+		return true
+	}
+	registrable, err := publicsuffix.EffectiveTLDPlusOne(normalized)
+	if err != nil {
+		return false
+	}
+	_, exists := v.registrableDomains[registrable]
 	return exists
+}
+
+func normalizeDomain(domain string) string {
+	trimmed := strings.TrimSpace(domain)
+	trimmed = strings.TrimRight(trimmed, ".")
+	if trimmed == "" {
+		return ""
+	}
+	ascii, err := idna.Lookup.ToASCII(trimmed)
+	if err != nil {
+		return strings.ToLower(trimmed)
+	}
+	return strings.ToLower(ascii)
 }

--- a/tests/unit/validator/disposable_validator_test.go
+++ b/tests/unit/validator/disposable_validator_test.go
@@ -39,6 +39,38 @@ func TestDisposableValidatorWithStaticReader(t *testing.T) {
 	}
 }
 
+func TestDisposableValidatorNormalizationAndSubdomains(t *testing.T) {
+	testDomains := []string{"TempMail.com", "sub.mailinator.com"}
+	reader := validator.NewStaticDomainReader(testDomains)
+
+	v, err := validator.NewDisposableValidatorWithReader(reader)
+	if err != nil {
+		t.Fatalf("Failed to create validator: %v", err)
+	}
+
+	tests := []struct {
+		domain string
+		want   bool
+	}{
+		{"tempmail.com", true},
+		{"TEMpMail.com", true},
+		{"tempmail.com.", true},
+		{"foo.tempmail.com", true},
+		{"sub.mailinator.com", true},
+		{"other.mailinator.com", false},
+		{"mailinator.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.domain, func(t *testing.T) {
+			got := v.Validate(tt.domain)
+			if got != tt.want {
+				t.Errorf("Validate(%q) = %v, want %v", tt.domain, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDisposableValidatorWithFileReader(t *testing.T) {
 	// Create a file reader with the config file
 	reader := validator.NewFileDomainReader("../../../config/disposable_domains.txt")


### PR DESCRIPTION
Add domain normalization and subdomain validation to disposable email checker
- Normalize domains by trimming, lowercasing and handling IDN
- Check subdomains against registrable domains
- Add tests for normalization and subdomain cases