### PR TITLE
fix: implement proper Redis caching for email validation

### DIFF
--- a/internal/service/email_service.go
+++ b/internal/service/email_service.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"log"
 	"runtime"
 	"strings"
 	"sync/atomic"
@@ -14,6 +15,9 @@ import (
 	"emailvalidator/pkg/validator"
 )
 
+// Default TTL for email validation result caching
+const emailCacheTTL = 24 * time.Hour
+
 // EmailService handles email validation operations
 type EmailService struct {
 	emailRuleValidator  EmailRuleValidator
@@ -21,6 +25,7 @@ type EmailService struct {
 	domainValidationSvc DomainValidationService
 	batchValidationSvc  *BatchValidationService
 	metricsCollector    MetricsCollector
+	redisCache          cache.Cache
 	startTime           time.Time
 	requests            int64
 }
@@ -47,6 +52,7 @@ func NewEmailServiceWithCache(redisCache cache.Cache) (*EmailService, error) {
 		domainValidationSvc: domainValidationSvc,
 		batchValidationSvc:  batchValidationSvc,
 		metricsCollector:    metricsAdapter,
+		redisCache:          redisCache,
 		startTime:           time.Now(),
 	}, nil
 }
@@ -80,9 +86,44 @@ func NewEmailServiceWithDeps(validator interface{}) *EmailService {
 	}
 }
 
+// getCachedEmailResult checks Redis for a cached email validation result
+func (s *EmailService) getCachedEmailResult(email string) (*model.EmailValidationResponse, bool) {
+	if s.redisCache == nil {
+		return nil, false
+	}
+
+	var result model.EmailValidationResponse
+	err := s.redisCache.Get(context.Background(), "email:"+strings.ToLower(email), &result)
+	if err != nil {
+		return nil, false
+	}
+
+	log.Printf("[Cache] Redis HIT for email:%s (status=%s, score=%d)", email, result.Status, result.Score)
+	return &result, true
+}
+
+// cacheEmailResult stores an email validation result in Redis
+func (s *EmailService) cacheEmailResult(email string, result model.EmailValidationResponse) {
+	if s.redisCache == nil {
+		return
+	}
+
+	key := "email:" + strings.ToLower(email)
+	if err := s.redisCache.Set(context.Background(), key, result, emailCacheTTL); err != nil {
+		log.Printf("[Cache] ERROR: Failed to write %s to Redis: %v", key, err)
+	} else {
+		log.Printf("[Cache] Wrote %s to Redis (status=%s, score=%d, ttl=%v)", key, result.Status, result.Score, emailCacheTTL)
+	}
+}
+
 // ValidateEmail performs all validation checks on a single email
 func (s *EmailService) ValidateEmail(email string) model.EmailValidationResponse {
 	atomic.AddInt64(&s.requests, 1)
+
+	// Check Redis cache first for full email result
+	if cached, found := s.getCachedEmailResult(email); found {
+		return *cached
+	}
 
 	response := model.EmailValidationResponse{
 		Email:       email,
@@ -165,6 +206,9 @@ func (s *EmailService) ValidateEmail(email string) model.EmailValidationResponse
 	default:
 		response.Status = model.ValidationStatusInvalid
 	}
+
+	// Cache the full result in Redis
+	s.cacheEmailResult(email, response)
 
 	return response
 }

--- a/pkg/validator/domain_cache.go
+++ b/pkg/validator/domain_cache.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"context"
+	"log"
 	"sync"
 	"time"
 
@@ -14,14 +15,26 @@ type domainCache struct {
 	timestamp time.Time
 }
 
-// DomainCacheResult is the structure stored in Redis cache
+// mxCache represents a cached MX lookup result
+type mxCache struct {
+	hasMX     bool
+	timestamp time.Time
+}
+
+// DomainCacheResult is the structure stored in Redis cache for domain existence
 type DomainCacheResult struct {
 	Exists bool `json:"exists"`
+}
+
+// MXCacheResult is the structure stored in Redis cache for MX records
+type MXCacheResult struct {
+	HasMX bool `json:"has_mx"`
 }
 
 // DomainCacheManager handles caching of domain validation results
 type DomainCacheManager struct {
 	localCache    map[string]domainCache
+	localMXCache  map[string]mxCache
 	cacheMutex    sync.RWMutex
 	cacheDuration time.Duration
 	redisCache    cache.Cache
@@ -31,6 +44,7 @@ type DomainCacheManager struct {
 func NewDomainCacheManager(duration time.Duration) *DomainCacheManager {
 	return &DomainCacheManager{
 		localCache:    make(map[string]domainCache, 100), // Pre-allocate space for better performance
+		localMXCache:  make(map[string]mxCache, 100),
 		cacheDuration: duration,
 		redisCache:    nil,
 	}
@@ -40,6 +54,7 @@ func NewDomainCacheManager(duration time.Duration) *DomainCacheManager {
 func NewDomainCacheManagerWithRedis(duration time.Duration, redisCache cache.Cache) *DomainCacheManager {
 	return &DomainCacheManager{
 		localCache:    make(map[string]domainCache, 100),
+		localMXCache:  make(map[string]mxCache, 100),
 		cacheDuration: duration,
 		redisCache:    redisCache,
 	}
@@ -68,6 +83,7 @@ func (m *DomainCacheManager) Get(domain string) (bool, bool) {
 				timestamp: time.Now(),
 			}
 			m.cacheMutex.Unlock()
+			log.Printf("[Cache] Redis L2 HIT for domain:%s (exists=%v)", domain, result.Exists)
 			return result.Exists, true
 		}
 	}
@@ -88,7 +104,63 @@ func (m *DomainCacheManager) Set(domain string, exists bool) {
 	// L2: Store in Redis if available
 	if m.redisCache != nil {
 		result := DomainCacheResult{Exists: exists}
-		_ = m.redisCache.Set(context.Background(), "domain:"+domain, result, m.cacheDuration)
+		if err := m.redisCache.Set(context.Background(), "domain:"+domain, result, m.cacheDuration); err != nil {
+			log.Printf("[Cache] ERROR: Failed to write domain:%s to Redis: %v", domain, err)
+		} else {
+			log.Printf("[Cache] Wrote domain:%s to Redis (exists=%v, ttl=%v)", domain, exists, m.cacheDuration)
+		}
+	}
+}
+
+// GetMX retrieves a cached MX validation result
+func (m *DomainCacheManager) GetMX(domain string) (bool, bool) {
+	// L1: Check local in-memory cache first
+	m.cacheMutex.RLock()
+	cached, ok := m.localMXCache[domain]
+	if ok && time.Since(cached.timestamp) <= m.cacheDuration {
+		m.cacheMutex.RUnlock()
+		return cached.hasMX, true
+	}
+	m.cacheMutex.RUnlock()
+
+	// L2: Fall back to Redis if available
+	if m.redisCache != nil {
+		var result MXCacheResult
+		err := m.redisCache.Get(context.Background(), "mx:"+domain, &result)
+		if err == nil {
+			// Populate L1 cache from L2 hit
+			m.cacheMutex.Lock()
+			m.localMXCache[domain] = mxCache{
+				hasMX:     result.HasMX,
+				timestamp: time.Now(),
+			}
+			m.cacheMutex.Unlock()
+			log.Printf("[Cache] Redis L2 HIT for mx:%s (hasMX=%v)", domain, result.HasMX)
+			return result.HasMX, true
+		}
+	}
+
+	return false, false
+}
+
+// SetMX stores an MX validation result in both L1 (local) and L2 (Redis) caches
+func (m *DomainCacheManager) SetMX(domain string, hasMX bool) {
+	// L1: Store in local in-memory cache
+	m.cacheMutex.Lock()
+	m.localMXCache[domain] = mxCache{
+		hasMX:     hasMX,
+		timestamp: time.Now(),
+	}
+	m.cacheMutex.Unlock()
+
+	// L2: Store in Redis if available
+	if m.redisCache != nil {
+		result := MXCacheResult{HasMX: hasMX}
+		if err := m.redisCache.Set(context.Background(), "mx:"+domain, result, m.cacheDuration); err != nil {
+			log.Printf("[Cache] ERROR: Failed to write mx:%s to Redis: %v", domain, err)
+		} else {
+			log.Printf("[Cache] Wrote mx:%s to Redis (hasMX=%v, ttl=%v)", domain, hasMX, m.cacheDuration)
+		}
 	}
 }
 
@@ -102,6 +174,11 @@ func (m *DomainCacheManager) ClearExpired() {
 			delete(m.localCache, domain)
 		}
 	}
+	for domain, cached := range m.localMXCache {
+		if now.Sub(cached.timestamp) > m.cacheDuration {
+			delete(m.localMXCache, domain)
+		}
+	}
 	m.cacheMutex.Unlock()
 }
 
@@ -110,6 +187,13 @@ func (m *DomainCacheManager) SetDuration(duration time.Duration) {
 	m.cacheMutex.Lock()
 	m.cacheDuration = duration
 	m.cacheMutex.Unlock()
+}
+
+// CacheDuration returns the current cache duration
+func (m *DomainCacheManager) CacheDuration() time.Duration {
+	m.cacheMutex.RLock()
+	defer m.cacheMutex.RUnlock()
+	return m.cacheDuration
 }
 
 // SetRedisCache sets the Redis cache backend

--- a/pkg/validator/domain_validator.go
+++ b/pkg/validator/domain_validator.go
@@ -46,26 +46,39 @@ func (v *DomainValidator) Validate(domain string) bool {
 
 // ValidateMX checks if the domain has valid MX records
 func (v *DomainValidator) ValidateMX(domain string) bool {
+	// Check cache first
+	if hasMX, found := v.cacheManager.GetMX(domain); found {
+		monitoring.RecordCacheOperation("mx_lookup", "hit")
+		return hasMX
+	}
+	monitoring.RecordCacheOperation("mx_lookup", "miss")
+
 	start := time.Now()
 	mxRecords, err := v.resolver.LookupMX(domain)
 	monitoring.RecordDNSLookup("mx", time.Since(start))
 
+	var hasMX bool
+
 	// If there's an error in lookup, the domain doesn't have valid MX records
 	if err != nil {
-		return false
+		hasMX = false
+	} else if len(mxRecords) == 0 {
+		// No MX records means the domain doesn't accept email
+		hasMX = false
+	} else if len(mxRecords) == 1 && mxRecords[0].Host == "." {
+		// Check for null MX record (RFC 7505)
+		// A single MX record with "." as the host indicates the domain doesn't accept email
+		hasMX = false
+	} else {
+		// Otherwise, the domain has valid MX records
+		hasMX = true
 	}
 
-	// No MX records means the domain doesn't accept email
-	if len(mxRecords) == 0 {
-		return false
-	}
+	// Update cache
+	v.cacheManager.SetMX(domain, hasMX)
 
-	// Check for null MX record (RFC 7505)
-	// A single MX record with "." as the host indicates the domain doesn't accept email
-	if len(mxRecords) == 1 && mxRecords[0].Host == "." {
-		return false
-	}
+	// Periodically clean up expired cache entries
+	go v.cacheManager.ClearExpired()
 
-	// Otherwise, the domain has valid MX records
-	return true
+	return hasMX
 }

--- a/pkg/validator/email.go
+++ b/pkg/validator/email.go
@@ -25,9 +25,9 @@ func NewEmailValidator() (*EmailValidator, error) {
 func NewEmailValidatorWithCache(redisCache cache.Cache) (*EmailValidator, error) {
 	var cacheManager *DomainCacheManager
 	if redisCache != nil {
-		cacheManager = NewDomainCacheManagerWithRedis(time.Hour, redisCache)
+		cacheManager = NewDomainCacheManagerWithRedis(24*time.Hour, redisCache)
 	} else {
-		cacheManager = NewDomainCacheManager(time.Hour)
+		cacheManager = NewDomainCacheManager(24 * time.Hour)
 	}
 	resolver := &DefaultResolver{timeout: 2 * time.Second}
 


### PR DESCRIPTION
## Problem
When running the container with REDIS_URL configured, no data was being saved to or retrieved from Redis.

## Root Causes
- Only domain A-record results were cached - MX lookups had no caching
- Full email validation results were never cached in Redis
- L1 in-memory cache masked the problem
- Redis write errors were silently discarded

## Changes
- **email_service.go** - Full email validation result caching (\`email:<address>\` keys, 24h TTL)
- **domain_cache.go** - Added MX caching (\`mx:<domain>\` keys), error logging
- **domain_validator.go** - MX results now cached like A-record results
- **email.go** - TTL increased from 1h to 24h

## Redis Key Structure
| Key | Content | TTL |
|-----|---------|-----|
| \`email:<address>\` | Full validation response | 24h |
| \`domain:<domain>\` | Domain exists (bool) | 24h |
| \`mx:<domain>\` | Has MX records (bool) | 24h |

## Testing
Verified locally with docker-compose-dev.yml + RedisInsight - keys are written and read correctly.
